### PR TITLE
Chrome image bug

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -3545,14 +3545,15 @@ Galleria.Picture.prototype = {
         }
 
         // begin preload and insert in cache when done
-        image.onload = function() {
+        $(image).bind('load', function() {
             self.original = {
                 height: this.height,
                 width: this.width
             };
             self.cache[ src ] = src; // will override old cache
             self.loaded = true;
-        };
+        });
+
 
         image.src = src;
         return image;


### PR DESCRIPTION
Fixes error in webkit 3.0 where the primary image would fail to display at times due to height and width both being set to zero. See http://groups.google.com/group/jquery-dev/browse_frm/thread/eee6ab7b2da50e1f?pli=1 for an explanation of the change.